### PR TITLE
include php.h - fixes build on my machine

### DIFF
--- a/zend_tombs.c
+++ b/zend_tombs.c
@@ -31,6 +31,7 @@
 # define ZEND_TOMBS_EXTENSION_API
 #endif
 
+#include "php.h"
 #include "zend_tombs.h"
 #include "zend_tombs_strings.h"
 #include "zend_tombs_graveyard.h"

--- a/zend_tombs_markers.c
+++ b/zend_tombs_markers.c
@@ -23,6 +23,7 @@
 # include "config.h"
 #endif
 
+#include "php.h"
 #include "zend.h"
 #include "zend_API.h"
 #include "zend_tombs.h"

--- a/zend_tombs_strings.h
+++ b/zend_tombs_strings.h
@@ -16,6 +16,8 @@
   +----------------------------------------------------------------------+
  */
 
+#include "php.h"
+
 #ifndef ZEND_TOMBS_STRINGS_H
 # define ZEND_TOMBS_STRINGS_H
 


### PR DESCRIPTION
I get errors like this without this included:
```
/home/user/tombs/zend_tombs_markers.h:23:5: error: unknown type name ‘zend_bool’
   23 |     zend_bool *markers;
      |     ^~~~~~~~~
/home/user/tombs/zend_tombs_markers.h:28:93: error: unknown type name ‘zend_bool’; did you mean ‘zend_op’?
   28 | static zend_always_inline zend_long zend_tombs_markers_index(zend_tombs_markers_t *markers, zend_bool *marker) {
      |                                                                                             ^~~~~~~~~
      |                                                                                             zend_op
/home/user/tombs/zend_tombs_markers.h:33:1: error: unknown type name ‘zend_bool’; did you mean ‘zend_op’?
   33 | zend_bool** zend_tombs_markers_create(zend_tombs_markers_t *markers);
      | ^~~~~~~~~
      | zend_op
/home/user/tombs/zend_tombs.c: In function ‘zend_tombs_setup’:
/home/user/tombs/zend_tombs.c:192:5: error: unknown type name ‘zend_bool’; did you mean ‘zend_op’?
  192 |     zend_bool **slot,
      |     ^~~~~~~~~
      |     zend_op
/home/user/tombs/zend_tombs.c:214:10: error: ‘zend_bool’ undeclared (first use in this function); did you mean ‘zend_atol’?
  214 |         (zend_bool**)
      |          ^~~~~~~~~
      |          zend_atol
/home/user/tombs/zend_tombs.c:214:10: note: each undeclared identifier is reported only once for each function it appears in
/home/user/tombs/zend_tombs.c:214:21: error: expected expression before ‘)’ token
  214 |         (zend_bool**)
      |                     ^
```