### PR TITLE
stop overwriting zend_execute_ex; start using observer api

### DIFF
--- a/zend_tombs.c
+++ b/zend_tombs.c
@@ -245,7 +245,7 @@ static zend_observer_fcall_handlers zend_tombs_observer_init( zend_execute_data 
 }
 
 // Called when a function is about to be executed, if zend_tombs_observer_init attached us to it.
-static void zend_tombs_observer_begin(zend_execute_data *execute_data)
+static zend_always_inline void zend_tombs_observer_begin(zend_execute_data *execute_data)
 {
     zend_op_array *ops = (zend_op_array*) EX(func);
     zend_bool *marker   = NULL,

--- a/zend_tombs.c
+++ b/zend_tombs.c
@@ -257,9 +257,7 @@ static void zend_tombs_observer_begin(zend_execute_data *execute_data)
         return;
     }
 
-    /* php_printf("Executing function: %s\n", ZSTR_VAL(ops->function_name)); */
     marker = __atomic_load_n(&ops->reserved[zend_tombs_resource], __ATOMIC_SEQ_CST);
-    /* php_printf("Marker address: %p\n", marker); */
 
     if (UNEXPECTED(NULL == marker)) {
         return;
@@ -272,7 +270,6 @@ static void zend_tombs_observer_begin(zend_execute_data *execute_data)
         0,
         __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST
     )) {
-        /* php_printf("Vacating graveyard\n"); */
         zend_tombs_graveyard_vacate(
             zend_tombs_graveyard,
             zend_tombs_markers_index(

--- a/zend_tombs.c
+++ b/zend_tombs.c
@@ -50,7 +50,6 @@ static void zend_tombs_shutdown(zend_extension *);
 static void zend_tombs_activate(void);
 static void zend_tombs_setup(zend_op_array*);
 static zend_observer_fcall_handlers zend_tombs_observer_init( zend_execute_data *execute_data );
-static void zend_tombs_observer_end(zend_execute_data *execute_data, zval *retval);
 static void zend_tombs_observer_begin(zend_execute_data *execute_data);
 
 ZEND_TOMBS_EXTENSION_API zend_extension_version_info extension_version_info = {
@@ -242,7 +241,7 @@ static zend_observer_fcall_handlers zend_tombs_observer_init( zend_execute_data 
     }
 
     // It's a user function, so we set up observers
-    return (zend_observer_fcall_handlers){zend_tombs_observer_begin, zend_tombs_observer_end};
+    return (zend_observer_fcall_handlers){zend_tombs_observer_begin, NULL};
 }
 
 // Called when a function is about to be executed, if zend_tombs_observer_init attached us to it.
@@ -276,8 +275,6 @@ static void zend_tombs_observer_begin(zend_execute_data *execute_data)
                 zend_tombs_markers, marker));
     }
 }
-
-static void zend_tombs_observer_end(zend_execute_data *execute_data, zval *retval) { }
 
 #if defined(ZTS) && defined(COMPILE_DL_TOMBS)
     ZEND_TSRMLS_CACHE_DEFINE();


### PR DESCRIPTION
PHP 8 introduces an observer API, which allows better monitoring and observability of PHP applications without causing significant performance issues or unexpected behavior. Datadog has written about it in [this article](https://href.li/?https://www.datadoghq.com/blog/engineering/php-8-observability-baked-right-in/). Newrelic’s php-agent [has implemented the new api](https://href.li/?https://github.com/newrelic/newrelic-php-agent/blob/4f470dac6640429416adff5b3937fc36c36f1f96/agent/php_execute.c#L2139-L2174).

- Avoids the limited native C stack that could lead to stack overflow and crashes when `zend_execute_ex` intercepted all PHP function calls
- Allows targeting specific PHP functions of interest rather than intercepting every single PHP function call, improving performance
- Works compatibly alongside the new JIT compiler introduced in PHP 8
- Handles forwarding hooks between extensions to avoid "noisy neighbor" issues and crashes from improper forwarding
- Provides a standard "observer" concept and API for future expansion of observability in the PHP engine
