### PR TITLE
 add function identification to avoid duplicates after recompiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run tests
       run: |
         EXT_DIR=$(php -r "echo ini_get('extension_dir');")
-        export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
+        export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1'"
         echo $TEST_PHP_ARGS
         make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Run tests
       run: |
         EXT_DIR=$(php -r "echo ini_get('extension_dir');")
-        export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d 'open_basedir=' -d 'output_buffering=0' -d 'memory_limit=-1'"
+        export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d open_basedir= -d output_buffering=0 -d memory_limit=-1"
         echo $TEST_PHP_ARGS
         make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,12 +39,8 @@ jobs:
       run: |
         php -m
 
-    - name: Find opcache path
-      run: |
-        php -r "echo ini_get('extension_dir');"
-
     - name: Run tests
       env:
-        TEST_PHP_ARGS: "-d zend_extension=/usr/lib/php/modules/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
+        TEST_PHP_ARGS: "-d zend_extension=$(php -r 'echo ini_get(\"extension_dir\");')/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
       run: make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,13 +45,5 @@ jobs:
         EXT_DIR=$(php -r "echo ini_get('extension_dir');")
         export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d open_basedir= -d output_buffering=0 -d memory_limit=-1"
         echo $TEST_PHP_ARGS
-        make test || true
-        echo "Log file"
-        cat tests/007.log
-        echo "Diff"
-        cat tests/007.diff
-        echo "Output"
-        cat tests/007.out
-        echo "Expected"
-        cat tests/007.exp
+        make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
         php -m
 
     - name: Run tests
-      env:
-        TEST_PHP_ARGS: "-d zend_extension=$(php -r 'echo ini_get(\"extension_dir\");')/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
       run: |
         EXT_DIR=$(php -r "echo ini_get('extension_dir');")
         export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,9 @@ jobs:
     - name: Run tests
       env:
         TEST_PHP_ARGS: "-d zend_extension=$(php -r 'echo ini_get(\"extension_dir\");')/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
-      run: make test
+      run: |
+        EXT_DIR=$(php -r "echo ini_get('extension_dir');")
+        export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
+        echo $TEST_PHP_ARGS
+        make test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,4 +45,12 @@ jobs:
         export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d open_basedir= -d output_buffering=0 -d memory_limit=-1"
         echo $TEST_PHP_ARGS
         make test
+        echo "Log file"
+        cat tests/007.log
+        echo "Diff"
+        cat tests/007.diff
+        echo "Output"
+        cat tests/007.out
+        echo "Expected"
+        cat tests/007.exp
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,11 @@ jobs:
 
     - name: Run tests
       run: |
+        export NO_INTERACTION=1
         EXT_DIR=$(php -r "echo ini_get('extension_dir');")
         export TEST_PHP_ARGS="-d zend_extension=${EXT_DIR}/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d open_basedir= -d output_buffering=0 -d memory_limit=-1"
         echo $TEST_PHP_ARGS
-        make test
+        make test || true
         echo "Log file"
         cat tests/007.log
         echo "Diff"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       uses: shivammathur/setup-php@v2
       with:
         php-version: '8.1'
-        extensions: mbstring
+        extensions: mbstring, opcache
         tools: phpize, php-config
 
     - name: Install PHP development package
@@ -39,6 +39,12 @@ jobs:
       run: |
         php -m
 
+    - name: Find opcache path
+      run: |
+        php -r "echo ini_get('extension_dir');"
+
     - name: Run tests
+      env:
+        TEST_PHP_ARGS: "-d zend_extension=/usr/lib/php/modules/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
       run: make test
 

--- a/LocalMakefileAdditions.mk
+++ b/LocalMakefileAdditions.mk
@@ -1,0 +1,10 @@
+# Target: test_opcache
+# Description: Runs the `test` target with OPcache enabled, setting necessary PHP ini parameters.
+test_opcache:
+	@echo "Running tests with OPcache enabled"
+	EXT_DIR=$$(php -r "echo ini_get('extension_dir');") ;\
+	TEST_PHP_ARGS="-d zend_extension=$$EXT_DIR/opcache.so -d opcache.enable=1 -d opcache.enable_cli=1 -d open_basedir= -d output_buffering=0 -d memory_limit=-1" ;\
+	export TEST_PHP_ARGS ;\
+	echo "Setting TEST_PHP_ARGS to: $$TEST_PHP_ARGS" ;\
+	$(MAKE) test
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Here is a quick run down of how to use Tombs ...
   - `make`
   - `make install`
 
+## To Run Tests:
+
+  - `make test`
+  - `make test_opcache` // enables an extra test that requires opcache module
+
 ## To load Tombs:
 
 Tombs must be loaded as a Zend extension:

--- a/config.m4
+++ b/config.m4
@@ -17,6 +17,7 @@ if test "$PHP_TOMBS" != "no"; then
         zend_tombs_strings.c \
         zend_tombs_markers.c \
         zend_tombs_graveyard.c \
+        zend_tombs_function_table.c \
         zend_tombs_io.c, 
         $ext_shared,,-DZEND_ENABLE_STATIC_TSRMLS_CACHE=1,,yes)
 

--- a/config.m4
+++ b/config.m4
@@ -23,3 +23,9 @@ if test "$PHP_TOMBS" != "no"; then
 
   PHP_SUBST(TOMBS_SHARED_LIBADD)
 fi
+
+AC_CONFIG_COMMANDS_PRE([cat >Makefile.tmp <<EOF
+-include LocalMakefileAdditions.mk
+EOF
+cat Makefile >> Makefile.tmp
+mv -f Makefile.tmp Makefile])

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Check if tomb is detected >1 (function)
+Check if opcache recompile leads to duplicate tombstones
 --EXTENSIONS--
 opcache
 --INI--

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Check if tomb is detected >1 (function)
+--EXTENSIONS--
+opcache
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+tombs.socket=tcp://127.0.0.1:8010
+--FILE--
+<?php
+// I had to run this test with "php run-tests.php -v tests/007.phpt", 
+// for some reason "make test" could not find opcache.
+include "zend_tombs.inc";
+include "007_helper.php";
+
+function test() {}
+function test2() {}
+
+test2();
+test4();
+$a = opcache_invalidate('007_helper.php', true);
+opcache_compile_file('007_helper.php');
+test4();
+
+zend_tombs_display("127.0.0.1", 8010);
+/*
+Bugged output (4 entries):
+{"location": {"file": "%s007.php", "start": 7, "end": 7}, "function": "test"}
+{"location": {"file": "%s007_helper.php", "start": 3, "end": 3}, "function": "test3"}
+{"location": {"file": "%s007_helper.php", "start": 3, "end": 3}, "function": "test3"}
+{"location": {"file": "%s007_helper.php", "start": 6, "end": 6}, "function": "test4"}
+Correct output below (2 entries):
+ */
+?>
+--EXPECTF--
+{"location": {"file": "%s007.php", "start": 7, "end": 7}, "function": "test"}
+{"location": {"file": "%s007_helper.php", "start": 3, "end": 3}, "function": "test3"}
+

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -8,7 +8,7 @@ opcache.enable_cli=1
 tombs.socket=tcp://127.0.0.1:8010
 --FILE--
 <?php
-// I had to run this test with "php run-tests.php -v tests/007.phpt", 
+// I had to run this test with "sudo make install", then "php run-tests.php -v tests/007.phpt",
 // for some reason "make test" could not find opcache.
 include "zend_tombs.inc";
 include "007_helper.php";

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -24,7 +24,7 @@ test4();
 zend_tombs_display("127.0.0.1", 8010);
 /*
 Bugged output (4 entries):
-{"location": {"file": "%s007.php", "start": 7, "end": 7}, "function": "test"}
+{"location": {"file": "%s007.php", "start": 6, "end": 6}, "function": "test"}
 {"location": {"file": "%s007_helper.php", "start": 3, "end": 3}, "function": "test3"}
 {"location": {"file": "%s007_helper.php", "start": 3, "end": 3}, "function": "test3"}
 {"location": {"file": "%s007_helper.php", "start": 6, "end": 6}, "function": "test4"}
@@ -32,6 +32,6 @@ Correct output below (2 entries):
  */
 ?>
 --EXPECTF--
-{"location": {"file": "%s007.php", "start": 7, "end": 7}, "function": "test"}
+{"location": {"file": "%s007.php", "start": 6, "end": 6}, "function": "test"}
 {"location": {"file": "%s007_helper.php", "start": 3, "end": 3}, "function": "test3"}
 

--- a/tests/007.phpt
+++ b/tests/007.phpt
@@ -8,8 +8,7 @@ opcache.enable_cli=1
 tombs.socket=tcp://127.0.0.1:8010
 --FILE--
 <?php
-// I had to run this test with "sudo make install", then "php run-tests.php -v tests/007.phpt",
-// for some reason "make test" could not find opcache.
+// If this test isn't running, try using "make test_opcache".
 include "zend_tombs.inc";
 include "007_helper.php";
 

--- a/tests/007_helper.php
+++ b/tests/007_helper.php
@@ -1,0 +1,7 @@
+<?php
+if (!function_exists('test3')) {
+    function test3() {}
+}
+if (!function_exists('test4')) {
+    function test4() {}
+}

--- a/zend_tombs_function_table.c
+++ b/zend_tombs_function_table.c
@@ -1,0 +1,71 @@
+#include "zend_tombs_function_table.h"
+#include "zend_tombs.h"
+
+zend_tombs_function_table_t *zend_tombs_function_table_startup(zend_long slots) {
+    zend_long function_table_size = slots * sizeof(zend_tombs_function_entry_t);
+    zend_tombs_function_table_t *table = zend_tombs_map(sizeof(zend_tombs_function_table_t) + function_table_size);
+    if (!table) {
+        zend_error(E_WARNING, "[TOMBS] Failed to allocate shared memory for function table");
+        return NULL;
+    }
+
+    memset(table, 0, sizeof(zend_tombs_function_table_t) + function_table_size);
+    table->size = slots;
+    table->used = 0;
+
+    // Initialize marker_index to -1 for all entries
+    for (zend_long i = 0; i < slots; i++) {
+        table->entries[i].marker_index = -1;
+    }
+
+    return table;
+}
+
+uint64_t zend_tombs_hash_key(const zend_op_array *ops) {
+    uint64_t hash = 5381;
+
+    if (ops->filename) {
+        hash = (hash * 33) + zend_string_hash_val(ops->filename);
+    }
+
+    if (ops->function_name) {
+        hash = (hash * 33) + zend_string_hash_val(ops->function_name);
+    } else {
+        // Use line numbers as a fallback for anonymous functions
+        hash = (hash * 33) + (uint64_t)ops->line_start;
+        hash = (hash * 33) + (uint64_t)ops->line_end;
+    }
+
+    if (ops->scope && ops->scope->name) {
+        hash = (hash * 33) + zend_string_hash_val(ops->scope->name);
+    }
+
+    return hash;
+}
+
+zend_tombs_function_entry_t *zend_tombs_function_find_or_insert(uint64_t hash, zend_tombs_function_table_t *table) {
+    zend_long slot = hash % table->size;
+    zend_long starting_slot = slot;
+
+    while (1) {
+        zend_tombs_function_entry_t *entry = &table->entries[slot];
+        zend_bool expected_used = 0;
+        if (__atomic_compare_exchange_n(&entry->used, &expected_used, 1, 0, __ATOMIC_RELAXED, __ATOMIC_RELAXED)) {
+            // Found an empty slot, insert the new entry
+            entry->hash = hash;
+            entry->used = 1;
+            __atomic_add_fetch(&table->used, 1, __ATOMIC_RELAXED);
+            return entry;
+        }
+        if (entry->hash == hash) {
+            return entry;
+        }
+        slot = (slot + 1) % table->size;
+        if (slot == starting_slot) {
+            // Hash table is full
+            return NULL;
+        }
+    }
+
+    return &table->entries[slot];
+}

--- a/zend_tombs_function_table.h
+++ b/zend_tombs_function_table.h
@@ -1,0 +1,27 @@
+#ifndef ZEND_TOMBS_FUNCTION_TABLE_H
+#define ZEND_TOMBS_FUNCTION_TABLE_H
+
+#include "php.h"
+#include "zend.h"
+#include "zend_string.h"
+#include "zend_types.h"
+#include "zend_hash.h"
+
+typedef struct _zend_tombs_function_entry_t {
+    uint64_t hash;
+    zend_long marker_index;
+    zend_bool used;
+} zend_tombs_function_entry_t;
+
+typedef struct _zend_tombs_function_table_t {
+    zend_long size;
+    zend_long used;
+    zend_tombs_function_entry_t entries[0];
+} zend_tombs_function_table_t;
+
+
+uint64_t zend_tombs_hash_key(const zend_op_array *ops);
+zend_tombs_function_entry_t *zend_tombs_function_find_or_insert(uint64_t hash, zend_tombs_function_table_t *thetab);
+zend_tombs_function_table_t *zend_tombs_function_table_startup(zend_long slots);
+
+#endif /* ZEND_TOMBS_FUNCTION_TABLE_H */

--- a/zend_tombs_markers.c
+++ b/zend_tombs_markers.c
@@ -67,6 +67,14 @@ zend_bool** zend_tombs_markers_create(zend_tombs_markers_t *markers) {
     return (zend_bool**) markers->markers + slot;
 }
 
+zend_bool** zend_tombs_markers_get(zend_tombs_markers_t *markers, zend_long slot) {
+    if (EXPECTED(slot < markers->slots)) {
+        return (zend_bool**) markers->markers + slot;
+    }
+
+    return NULL;
+}
+
 void zend_tombs_markers_shutdown(zend_tombs_markers_t *markers) {
     zend_tombs_unmap(markers, zend_tombs_markers_size(markers->slots));
 }

--- a/zend_tombs_markers.h
+++ b/zend_tombs_markers.h
@@ -31,6 +31,7 @@ static zend_always_inline zend_long zend_tombs_markers_index(zend_tombs_markers_
 
 zend_tombs_markers_t* zend_tombs_markers_startup(zend_long slots);
 zend_bool** zend_tombs_markers_create(zend_tombs_markers_t *markers);
+zend_bool** zend_tombs_markers_get(zend_tombs_markers_t *markers, zend_long slot);
 void zend_tombs_markers_shutdown(zend_tombs_markers_t *markers);
 
 #endif	/* ZEND_TOMBS_MARKERS_H */


### PR DESCRIPTION
Previously, new markers and tombs were created for each compiled
function, even if the function had already been processed before. This
lead to duplicate entries and wasted slots when a file was recompiled
and a function was encountered multiple times (for example, after
deploying code which will invalidate opcache entries).

Here, we add a function identification mechanism to reuse existing
markers instead of duplicating them.

- Adds a zend_tombs_function_entry_t struct to represent a function
  entry in the function table. Contains the function's hash key, marker
  index, and a used flag.
- Adds a zend_tombs_function_table_t struct to hold the function entries
  in a hash table. Allocated using zend_tombs_map() to share memory
  across workers.
- Adds a zend_tombs_hash_key() function to calculate a hash key for each
  function based on its filename, function name (or line numbers for
  anonymous functions), and scope.
- Adds a zend_tombs_function_find_or_insert() function to lookup or
  insert an entry in the table. Uses open addressing in case of
  collisions.
- Changes zend_tombs_setup() to use the new function identification
  method. If an existing entry is found for a function, we reuse the
  existing marker and tomb. If a new entry is needed, we continue to
  make a new marker and tomb.

Note: There is an issue with "make test" not running the new test on both my machine and github, because it requires opcache. To run it locally, I have to `sudo make install` and then `php run-tests.php tests/007.phpt` which runs the test using the system installed version of the extension. Obviously, this isn't ideal. If you know how to fix, please help :)