### PR TITLE
update zend_error calls to php_error_docref

### DIFF
--- a/zend_tombs.c
+++ b/zend_tombs.c
@@ -83,7 +83,7 @@ static int zend_tombs_startup(zend_extension *ze) {
     zend_tombs_ini_startup();
 
     if (!zend_tombs_ini_socket && !zend_tombs_ini_dump) {
-        zend_error(E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "[TOMBS] socket and dump are both disabled by configuration, "
             "may be misconfigured");
         zend_tombs_ini_shutdown();

--- a/zend_tombs_function_table.c
+++ b/zend_tombs_function_table.c
@@ -5,7 +5,7 @@ zend_tombs_function_table_t *zend_tombs_function_table_startup(zend_long slots) 
     zend_long function_table_size = slots * sizeof(zend_tombs_function_entry_t);
     zend_tombs_function_table_t *table = zend_tombs_map(sizeof(zend_tombs_function_table_t) + function_table_size);
     if (!table) {
-        zend_error(E_WARNING, "[TOMBS] Failed to allocate shared memory for function table");
+        php_error_docref(NULL, E_WARNING, "[TOMBS] Failed to allocate shared memory for function table");
         return NULL;
     }
 

--- a/zend_tombs_graveyard.c
+++ b/zend_tombs_graveyard.c
@@ -97,7 +97,7 @@ zend_tombs_graveyard_t* zend_tombs_graveyard_startup(zend_long slots) {
     zend_tombs_graveyard_t *graveyard = zend_tombs_map(size);
 
     if (!graveyard) {
-        zend_error(E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "[TOMBS] Failed to allocate shared memory for graveyard");
         return NULL;
     }

--- a/zend_tombs_io.c
+++ b/zend_tombs_io.c
@@ -124,7 +124,7 @@ zend_tombs_io_type_t zend_tombs_io_setup(char *uri, struct sockaddr **sa, int *s
             try = socket(un->sun_family, SOCK_STREAM, 0);
 
             if (try == -1) {
-                zend_error(E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "[TOMBS] %s - cannot create socket for %s",
                     strerror(errno),
                     uri);
@@ -146,7 +146,7 @@ zend_tombs_io_type_t zend_tombs_io_setup(char *uri, struct sockaddr **sa, int *s
                 return type;
             }
 
-            zend_error(E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "[TOMBS] %s - cannot create socket for %s",
                 strerror(errno),
                 uri);
@@ -169,7 +169,7 @@ zend_tombs_io_type_t zend_tombs_io_setup(char *uri, struct sockaddr **sa, int *s
             gai_errno = getaddrinfo(address, port, &hi, &ai);
 
             if (gai_errno != SUCCESS) {
-                zend_error(E_WARNING,
+                php_error_docref(NULL, E_WARNING,
                     "[TOMBS] %s - failed to get address for %s",
                     gai_strerror(gai_errno),
                     uri);
@@ -208,7 +208,7 @@ zend_tombs_io_type_t zend_tombs_io_setup(char *uri, struct sockaddr **sa, int *s
                 close(try);
             }
 
-            zend_error(E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "[TOMBS] %s - cannot create socket for %s",
                 strerror(errno),
                 uri);
@@ -217,7 +217,7 @@ zend_tombs_io_type_t zend_tombs_io_setup(char *uri, struct sockaddr **sa, int *s
         } break;
 
         case ZEND_TOMBS_IO_UNKNOWN:
-            zend_error(E_WARNING,
+            php_error_docref(NULL, E_WARNING,
                 "[TOMBS] Failed to setup socket, %s is a malformed uri",
                 uri);
         break;
@@ -247,7 +247,7 @@ zend_bool zend_tombs_io_startup(char *uri, zend_tombs_graveyard_t *graveyard)
     }
 
     if (listen(ZTIO(descriptor), 256) != SUCCESS) {
-        zend_error(E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "[TOMBS] %s - cannot listen on %s, ",
             strerror(errno), uri);
         zend_tombs_io_shutdown();
@@ -257,7 +257,7 @@ zend_bool zend_tombs_io_startup(char *uri, zend_tombs_graveyard_t *graveyard)
     ZTIO(graveyard) = graveyard;
 
     if (pthread_create(&ZTIO(thread), NULL, zend_tombs_io_routine, NULL) != SUCCESS) {
-        zend_error(E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "[TOMBS] %s - cannot create thread for io on %s",
             strerror(errno), uri);
         zend_tombs_io_shutdown();

--- a/zend_tombs_markers.c
+++ b/zend_tombs_markers.c
@@ -40,7 +40,7 @@ zend_tombs_markers_t* zend_tombs_markers_startup(zend_long slots) {
     markers = (zend_tombs_markers_t*) zend_tombs_map(size);
 
     if (!markers) {
-        zend_error(E_WARNING, 
+        php_error_docref(NULL, E_WARNING, 
             "[TOMBS] Failed to allocate shared memory for markers");
         return NULL;
     }

--- a/zend_tombs_strings.c
+++ b/zend_tombs_strings.c
@@ -121,7 +121,7 @@ zend_bool zend_tombs_strings_startup(zend_long strings) {
     zend_tombs_strings = zend_tombs_map(strings + sizeof(zend_tombs_strings_t));
 
     if (!zend_tombs_strings) {
-        zend_error(E_WARNING,
+        php_error_docref(NULL, E_WARNING,
             "[TOMBS] Failed to allocate shared memory for strings");
         return 0;
     }


### PR DESCRIPTION
According to the PHP wiki, we shouldn't be using zend_error:

https://wiki.php.net/internals/review_comments


>Don't use zend_error

>zend_error() should only be used inside the engine. Inside PHP extensions only PHP's error functions shoudl be used. Typically php_error_docref() is the best choice. php_error_docref() will extend the error message by extra information, like the current function name and properly escape output where needed. zend_error() is used by the Zend Engine due to PHP's modular architecture where the Zend Engine and TSRM should be compilable without other parts of PHP. The engine therefore can not use PHP level APIs. This limitation does not exist in extensions.
