### PR TITLE
add zend_tombs_function_table_shutdown

### DIFF
--- a/zend_tombs.c
+++ b/zend_tombs.c
@@ -163,6 +163,7 @@ static void zend_tombs_shutdown(zend_extension *ze) {
         zend_tombs_graveyard_dump(zend_tombs_graveyard, zend_tombs_ini_dump);
     }
 
+    zend_tombs_function_table_shutdown(zend_tombs_function_table);
     zend_tombs_io_shutdown();
     zend_tombs_graveyard_shutdown(zend_tombs_graveyard);
     zend_tombs_markers_shutdown(zend_tombs_markers);

--- a/zend_tombs_function_table.c
+++ b/zend_tombs_function_table.c
@@ -69,3 +69,12 @@ zend_tombs_function_entry_t *zend_tombs_function_find_or_insert(uint64_t hash, z
 
     return &table->entries[slot];
 }
+
+void zend_tombs_function_table_shutdown(zend_tombs_function_table_t *table) {
+    if (table) {
+        zend_long function_table_size = table->size * sizeof(zend_tombs_function_entry_t);
+        zend_long total_size = sizeof(zend_tombs_function_table_t) + function_table_size;
+
+        zend_tombs_unmap(table, total_size);
+    }
+}

--- a/zend_tombs_function_table.h
+++ b/zend_tombs_function_table.h
@@ -21,7 +21,8 @@ typedef struct _zend_tombs_function_table_t {
 
 
 uint64_t zend_tombs_hash_key(const zend_op_array *ops);
-zend_tombs_function_entry_t *zend_tombs_function_find_or_insert(uint64_t hash, zend_tombs_function_table_t *thetab);
 zend_tombs_function_table_t *zend_tombs_function_table_startup(zend_long slots);
+zend_tombs_function_entry_t *zend_tombs_function_find_or_insert(uint64_t hash, zend_tombs_function_table_t *thetab);
+void zend_tombs_function_table_shutdown(zend_tombs_function_table_t *table);
 
 #endif /* ZEND_TOMBS_FUNCTION_TABLE_H */


### PR DESCRIPTION
The shutdown sequence was missing an unmap for the new shared memory in zend_tombs_function_table created by #6.