### PR TITLE
fix race condition in zend_tombs_function_find_or_insert

### DIFF
--- a/zend_tombs_function_table.h
+++ b/zend_tombs_function_table.h
@@ -10,7 +10,7 @@
 typedef struct _zend_tombs_function_entry_t {
     uint64_t hash;
     zend_long marker_index;
-    zend_bool used;
+    int8_t used;
 } zend_tombs_function_entry_t;
 
 typedef struct _zend_tombs_function_table_t {


### PR DESCRIPTION
When multiple threads were getting function entries, sometimes a race condition would lead to the same function hash creating multiple function entries:
```
[TOMBS] Calculated Hash | PID: 146644 | ID: 4d11 | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14e8 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146652 | ID: 9564 | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a1500 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146646 | ID: d3b5 | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146651 | ID: c8fb | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146650 | ID: b215 | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146645 | ID: 4be5 | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146648 | ID: fcec | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146649 | ID: c49a | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146647 | ID: be8f | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
[TOMBS] Calculated Hash | PID: 146643 | ID: 3d40 | Hash: 14076587013372303976 | Entry Address: 0x70fc7e5a14d0 | File: /srv/http/wordpress/wp-content/plugins/jetpack/class.jetpack-post-images.php | Function: from_slideshow
```

The problem would be one thread failing the exchange for 0 1 in ->used, then it would immediately check `if (entry->hash == hash) { return entry; }`. However, another thread would be in the process of writing to this entry when the hash check went off. Therefore, we mark used = -1 when writing to it, then move the -1 to 1 to indicate we're done. If we see a -1, then wait (this should not be common and only happen when multiple workers are compiling the same file at the same time)


Test with
```
seq 1 100 | xargs -I {} -P100 curl -s http://wp.localdomain/ > /tmp/output
```

and then
```
socat - UNIX-CONNECT:/zend.tombs.socket | sort | uniq -c | sort -n
```